### PR TITLE
Configure site-to-site VPN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 base/.vagrant
 base.box
 base/*.log
+pki/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,40 +74,12 @@ Vagrant.configure("2") do |config|
       vb.customize ['modifyvm', :id, '--natnet1', '192.168.112.0/24']
       # Performance
       vb.cpus = 1
-      vb.memory = 256
+      vb.memory = 512
       vb.linked_clone = true
       vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
     end
     # Install dependencies and define the NAT
     gateway_a.vm.provision :shell, run: "always", path: "scripts/site_a_gateway.sh"
-  end
-
-  # Local server A
-  config.vm.define "server-a" do |server_a|
-    server_a.vm.box = "base"
-    server_a.vm.hostname = "server-a"
-    server_a.vbguest.auto_update = false
-    ## NETWORK INTERFACES
-    # Interface towards customer site network
-    server_a.vm.network "private_network",
-      ip: "10.1.0.99",
-      netmask: "255.255.0.0",
-      virtualbox__intnet: "intranet_a"
-    server_a.vm.provider "virtualbox" do |vb|
-      vb.name = "server-a"
-      # Change the default Vagrant ssh address
-      vb.customize ['modifyvm', :id, '--natnet1', '192.168.113.0/24']
-      # Performance
-      vb.cpus = 1
-      vb.memory = 512
-      vb.linked_clone = true
-      vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
-    end
-    # Server app
-    server_a.vm.provision :file, source: './apps/server_app',
-      destination: "server_app"
-    # Install dependencies and define the NAT
-    server_a.vm.provision :shell, run: "always", path: "scripts/local_server.sh"
   end
 
   # Client A1
@@ -193,40 +165,12 @@ Vagrant.configure("2") do |config|
       vb.customize ['modifyvm', :id, '--natnet1', '192.168.116.0/24']
       # Performance
       vb.cpus = 1
-      vb.memory = 256
+      vb.memory = 512
       vb.linked_clone = true
       vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
     end
     # Install dependencies and define the NAT
     gateway_b.vm.provision :shell, run: "always", path: "scripts/site_b_gateway.sh"
-  end
-
-  # Local server B
-  config.vm.define "server-b" do |server_b|
-    server_b.vm.box = "base"
-    server_b.vm.hostname = "server-b"
-    server_b.vbguest.auto_update = false
-    ## NETWORK INTERFACES
-    # Interface towards customer site network
-    server_b.vm.network "private_network",
-      ip: "10.1.0.99",
-      netmask: "255.255.0.0",
-      virtualbox__intnet: "intranet_b"
-    server_b.vm.provider "virtualbox" do |vb|
-      vb.name = "server-b"
-      # Change the default Vagrant ssh address
-      vb.customize ['modifyvm', :id, '--natnet1', '192.168.117.0/24']
-      # Performance
-      vb.cpus = 1
-      vb.memory = 512
-      vb.linked_clone = true
-      vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
-    end
-    # Server app
-    server_b.vm.provision :file, source: './apps/server_app',
-      destination: "server_app"
-    # Install dependencies and define the NAT
-    server_b.vm.provision :shell, run: "always", path: "scripts/local_server.sh"
   end
 
   # Client B1
@@ -316,7 +260,7 @@ Vagrant.configure("2") do |config|
       vb.customize ['modifyvm', :id, '--natnet1', '192.168.120.0/24']
       # Performance
       vb.cpus = 1
-      vb.memory = 256
+      vb.memory = 512
       vb.linked_clone = true
       vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
     end

--- a/config/swanctl-cloud-s.conf
+++ b/config/swanctl-cloud-s.conf
@@ -1,0 +1,21 @@
+connections {
+    cloud-site {
+        local_addrs = 172.30.30.30
+        remote_addrs = 172.30.30.30
+        local {
+            auth = pubkey
+            certs = cloudSCert.pem
+        }
+        remote {
+            auth = pubkey
+            id = "C=FI, O=Network Security, CN=Cloud S"
+        }
+        children {
+            net-net {
+                local_ts  = 10.1.0.0/16
+                remote_ts = 172.48.48/28
+                start_action = trap
+            }
+        }
+    }
+}

--- a/config/swanctl-cloud-s.conf
+++ b/config/swanctl-cloud-s.conf
@@ -16,7 +16,7 @@ connections {
                 local_ts = 172.48.48.48/28, 172.30.30.30/32
                 remote_ts = 10.1.0.0/16, 172.16.16.16/32
 
-                updown = /usr/local/libexec/ipsec/_updown iptables
+                # updown = /usr/local/libexec/ipsec/_updown iptables
                 esp_proposals = default
 
                 # installs a trap policy which triggers the tunnel 

--- a/config/swanctl-cloud-s.conf
+++ b/config/swanctl-cloud-s.conf
@@ -1,21 +1,61 @@
 connections {
-    cloud-site {
+    cloud-to-site-a {
         local_addrs = 172.30.30.30
-        remote_addrs = 172.30.30.30
+        remote_addrs = 172.16.16.16
         local {
             auth = pubkey
             certs = cloudSCert.pem
+            id = "C=FI, O=Network Security, CN=Cloud S"
         }
         remote {
             auth = pubkey
-            id = "C=FI, O=Network Security, CN=Cloud S"
+            id = "C=FI, O=Network Security, CN=Site A"
         }
         children {
             net-net {
-                local_ts  = 10.1.0.0/16
-                remote_ts = 172.48.48/28
+                local_ts = 172.48.48.48/28, 172.30.30.30/32
+                remote_ts = 10.1.0.0/16, 172.16.16.16/32
+
+                updown = /usr/local/libexec/ipsec/_updown iptables
+                esp_proposals = default
+
+                # installs a trap policy which triggers the tunnel 
+                # as soon as matching traffic has been detected
                 start_action = trap
             }
         }
+        # IKEv2
+        version = 2
+        proposals = default
+    }
+
+    cloud-to-site-b {
+        local_addrs = 172.30.30.30
+        remote_addrs = 172.18.18.18
+        local {
+            auth = pubkey
+            certs = cloudSCert.pem
+            id = "C=FI, O=Network Security, CN=Cloud S"
+        }
+        remote {
+            auth = pubkey
+            id = "C=FI, O=Network Security, CN=Site B"
+        }
+        children {
+            net-net {
+                local_ts = 172.48.48.48/28
+                remote_ts = 10.1.0.0/16
+
+                updown = /usr/local/libexec/ipsec/_updown iptables
+                esp_proposals = default
+
+                # installs a trap policy which triggers the tunnel 
+                # as soon as matching traffic has been detected
+                start_action = trap
+            }
+        }
+        # IKEv2
+        version = 2
+        proposals = default
     }
 }

--- a/config/swanctl-site-a.conf
+++ b/config/swanctl-site-a.conf
@@ -1,10 +1,11 @@
 connections {
-    site-a-cloud {
+    site-a-to-cloud {
         local_addrs = 172.16.16.16
         remote_addrs = 172.30.30.30
         local {
             auth = pubkey
             certs = siteACert.pem
+            id = "C=FI, O=Network Security, CN=Site A"
         }
         remote {
             auth = pubkey
@@ -12,10 +13,19 @@ connections {
         }
         children {
             net-net {
-                local_ts  = 10.1.0.0/16
-                remote_ts = 172.48.48/28
+                local_ts = 10.1.0.0/16, 172.16.16.16/32
+                remote_ts = 172.48.48.48/28, 172.30.30.30/32
+
+                updown = /usr/local/libexec/ipsec/_updown iptables
+                esp_proposals = default
+
+                # installs a trap policy which triggers the tunnel 
+                # as soon as matching traffic has been detected
                 start_action = trap
             }
         }
+        # IKEv2
+        version = 2
+        proposals = default
     }
 }

--- a/config/swanctl-site-a.conf
+++ b/config/swanctl-site-a.conf
@@ -16,7 +16,7 @@ connections {
                 local_ts = 10.1.0.0/16, 172.16.16.16/32
                 remote_ts = 172.48.48.48/28, 172.30.30.30/32
 
-                updown = /usr/local/libexec/ipsec/_updown iptables
+                # updown = /usr/local/libexec/ipsec/_updown iptables
                 esp_proposals = default
 
                 # installs a trap policy which triggers the tunnel 

--- a/config/swanctl-site-a.conf
+++ b/config/swanctl-site-a.conf
@@ -1,0 +1,21 @@
+connections {
+    site-a-cloud {
+        local_addrs = 172.16.16.16
+        remote_addrs = 172.30.30.30
+        local {
+            auth = pubkey
+            certs = siteACert.pem
+        }
+        remote {
+            auth = pubkey
+            id = "C=FI, O=Network Security, CN=Cloud S"
+        }
+        children {
+            net-net {
+                local_ts  = 10.1.0.0/16
+                remote_ts = 172.48.48/28
+                start_action = trap
+            }
+        }
+    }
+}

--- a/config/swanctl-site-b.conf
+++ b/config/swanctl-site-b.conf
@@ -1,0 +1,21 @@
+connections {
+    site-b-cloud {
+        local_addrs = 172.18.18.18
+        remote_addrs = 172.30.30.30
+        local {
+            auth = pubkey
+            certs = siteBCert.pem
+        }
+        remote {
+            auth = pubkey
+            id = "C=FI, O=Network Security, CN=Cloud S"
+        }
+        children {
+            net-net {
+                local_ts  = 10.1.0.0/16
+                remote_ts = 172.48.48/28
+                start_action = trap
+            }
+        }
+    }
+}

--- a/config/swanctl-site-b.conf
+++ b/config/swanctl-site-b.conf
@@ -13,10 +13,10 @@ connections {
         }
         children {
             net-net {
-                local_ts  = 10.1.0.0/16
-                remote_ts = 172.48.48.48/28
+                local_ts = 10.1.0.0/16, 172.18.18.18/32
+                remote_ts = 172.48.48.48/28, 172.30.30.30/32
 
-                updown = /usr/local/libexec/ipsec/_updown iptables
+                # updown = /usr/local/libexec/ipsec/_updown iptables
                 esp_proposals = default
 
                 # installs a trap policy which triggers the tunnel 

--- a/config/swanctl-site-b.conf
+++ b/config/swanctl-site-b.conf
@@ -1,10 +1,11 @@
 connections {
-    site-b-cloud {
+    site-b-to-cloud {
         local_addrs = 172.18.18.18
         remote_addrs = 172.30.30.30
         local {
             auth = pubkey
             certs = siteBCert.pem
+            id = "C=FI, O=Network Security, CN=Site B"
         }
         remote {
             auth = pubkey
@@ -13,9 +14,18 @@ connections {
         children {
             net-net {
                 local_ts  = 10.1.0.0/16
-                remote_ts = 172.48.48/28
+                remote_ts = 172.48.48.48/28
+
+                updown = /usr/local/libexec/ipsec/_updown iptables
+                esp_proposals = default
+
+                # installs a trap policy which triggers the tunnel 
+                # as soon as matching traffic has been detected
                 start_action = trap
             }
         }
+        # IKEv2
+        version = 2
+        proposals = default
     }
 }

--- a/doc/certificate.md
+++ b/doc/certificate.md
@@ -1,0 +1,20 @@
+# Generate certificates for gateways
+> Created: 2023-04-11
+
+These steps need to be run before the VMs started, otherwise the certificates and private keys cannot be loaded into the VMs.
+
+First install the dependency on the host machine.
+
+```shell
+sudo apt install strongswan-pki
+```
+
+Run `scripts/gen_cert.sh` at the **root directory of the project**. Make sure the `pki` folder is generated.
+
+Create the VMs, the VMs that have a certificate are `gateway-a`, `gateway-b`, and `gateway-s`.
+
+```shell
+vagrant up [vm]
+```
+
+See [Certificates Quickstart :: strongSwan Documentation](https://docs.strongswan.org/docs/5.9/pki/pkiQuickstart.html) for more information.

--- a/doc/site-to-site-vpn.md
+++ b/doc/site-to-site-vpn.md
@@ -1,0 +1,12 @@
+# Site-to-site VPN
+> Created: 2023-04-11
+
+We have to create two tunnels, one between **Site A** and **Cloud S**, another between **Site B** and **Cloud S**.
+
+All the configuration files are stored under `config/`. They will be loaded into the VMs during start up.
+
+## Resources
+- [Configuration Quickstart :: strongSwan Documentation](https://docs.strongswan.org/docs/5.9/config/quickstart.html#_host_to_host_case)
+- [swanctl.conf :: strongSwan Documentation](https://docs.strongswan.org/docs/6.0/swanctl/swanctlConf.html)
+- [IKEv2 Configuration Examples :: strongSwan Documentation](https://docs.strongswan.org/docs/5.9/config/IKEv2.html)
+- [IKEv2 | Site-to-Site | RSA authentication with X.509 certificates | IPv4](https://www.strongswan.org/testing/testresults/ikev2/net2net-cert/)

--- a/scripts/cloud_s_gateway.sh
+++ b/scripts/cloud_s_gateway.sh
@@ -11,8 +11,8 @@ iptables-save > /etc/iptables/rules.v4
 ip6tables-save > /etc/iptables/rules.v6
 
 # install swanctl
-sudo apt-get update -y
-sudo apt-get install -y strongswan-swanctl
+apt-get update -y
+apt-get install -y strongswan-swanctl charon-systemd
 
 # Root CA certificate
 cp /vagrant/pki/cert/rootCACert.pem /etc/swanctl/x509ca/

--- a/scripts/cloud_s_gateway.sh
+++ b/scripts/cloud_s_gateway.sh
@@ -9,3 +9,19 @@ route add default gw 172.30.30.1
 ## Save the iptables rules
 iptables-save > /etc/iptables/rules.v4
 ip6tables-save > /etc/iptables/rules.v6
+
+# install swanctl
+sudo apt-get update -y
+sudo apt-get install -y strongswan-swanctl
+
+# Root CA certificate
+cp /vagrant/pki/cert/rootCACert.pem /etc/swanctl/x509ca/
+
+# Cloud S certificate
+cp /vagrant/pki/cert/cloudSCert.pem /etc/swanctl/x509/
+
+# Cloud S private key
+cp /vagrant/pki/key/cloudSKey.pem /etc/swanctl/private/
+
+# swanctl configurations
+cp /vagrant/config/swanctl-cloud-s.conf /etc/swanctl/swanctl.conf

--- a/scripts/cloud_s_gateway.sh
+++ b/scripts/cloud_s_gateway.sh
@@ -25,3 +25,9 @@ cp /vagrant/pki/key/cloudSKey.pem /etc/swanctl/private/
 
 # swanctl configurations
 cp /vagrant/config/swanctl-cloud-s.conf /etc/swanctl/swanctl.conf
+
+# load the certificates and private keys into the charon daemon
+swanctl --load-creds
+
+# load the connections defined in swanctl.conf
+swanctl --load-conns

--- a/scripts/gen_cert.sh
+++ b/scripts/gen_cert.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+mkdir -p pki/{key,req,cert}
+
+##### Root CA #####
+
+# generates an elliptic Edwards-Curve key
+# with a cryptographic strength of 128 bits
+# rootCAKey.pem is the generated private key
+pki --gen --type ed25519 --outform pem > pki/key/rootCAKey.pem
+
+# generates a self-signed X.509 certificate
+# with a lifetime of 10 years (3652 days)
+pki --self --ca --lifetime 3652 --in pki/key/rootCAKey.pem \
+           --dn "C=FI, O=Network Security, CN=Network Security Root CA" \
+           --outform pem > pki/cert/rootCACert.pem
+
+
+##### Site A #####
+
+pki --gen --type ed25519 --outform pem > pki/key/siteAKey.pem
+
+# generates a PKCS#10 certificate request
+# use IPv4 address as subjectAltName
+pki --req --type priv --in pki/key/siteAKey.pem \
+          --dn "C=FI, O=Network Security, CN=Site A" \
+          --san 172.16.16.16 --outform pem > pki/req/siteAReq.pem
+
+# generates an X.509 certificate signed with a CA’s private key
+# with a lifetime of 5 years (1826 days)
+pki --issue --cacert pki/cert/rootCACert.pem --cakey pki/key/rootCAKey.pem \
+            --type pkcs10 --in pki/req/siteAReq.pem --lifetime 1826 \
+            --outform pem > pki/cert/siteACert.pem
+
+
+##### Site B #####
+
+pki --gen --type ed25519 --outform pem > pki/key/siteBKey.pem
+pki --req --type priv --in pki/key/siteBKey.pem \
+          --dn "C=FI, O=Network Security, CN=Site B" \
+          --san 172.18.18.18 --outform pem > pki/req/siteBReq.pem
+pki --issue --cacert pki/cert/rootCACert.pem --cakey pki/key/rootCAKey.pem \
+            --type pkcs10 --in pki/req/siteBReq.pem --lifetime 1826 \
+            --outform pem > pki/cert/siteBCert.pem
+
+
+##### Cloud S #####
+
+pki --gen --type ed25519 --outform pem > pki/key/cloudSKey.pem
+pki --req --type priv --in pki/key/cloudSKey.pem \
+          --dn "C=FI, O=Network Security, CN=Cloud S" \
+          --san 172.30.30.30 --outform pem > pki/req/cloudSReq.pem
+pki --issue --cacert pki/cert/rootCACert.pem --cakey pki/key/rootCAKey.pem \
+            --type pkcs10 --in pki/req/cloudSReq.pem --lifetime 1826 \
+            --outform pem > pki/cert/cloudSCert.pem

--- a/scripts/site_a_gateway.sh
+++ b/scripts/site_a_gateway.sh
@@ -7,3 +7,19 @@ iptables -t nat -A POSTROUTING -o enp0s8 -j MASQUERADE
 ## Save the iptables rules
 iptables-save > /etc/iptables/rules.v4
 ip6tables-save > /etc/iptables/rules.v6
+
+# install swanctl
+sudo apt-get update -y
+sudo apt-get install -y strongswan-swanctl
+
+# Root CA certificate
+cp /vagrant/pki/cert/rootCACert.pem /etc/swanctl/x509ca/
+
+# Site A certificate
+cp /vagrant/pki/cert/siteACert.pem /etc/swanctl/x509/
+
+# Site A private key
+cp /vagrant/pki/key/siteAKey.pem /etc/swanctl/private/
+
+# swanctl configurations
+cp /vagrant/config/swanctl-site-a.conf /etc/swanctl/swanctl.conf

--- a/scripts/site_a_gateway.sh
+++ b/scripts/site_a_gateway.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 
-## NAT traffic going to the internet
+##### Setup iptables rules #####
+
+# NAT traffic going to the internet
 route add default gw 172.16.16.1
 iptables -t nat -A POSTROUTING -o enp0s8 -j MASQUERADE
 
-## Save the iptables rules
+# Redirect traffic that was going to the local server to the cloud server
+# DNAT stands for Destination NAT
+ip addr add 10.1.0.99/16 dev enp0s9
+iptables -t nat -A PREROUTING -p tcp -d 10.1.0.99 --dport 8080 -j DNAT --to-destination 172.48.48.51:8080
+
+# Save the iptables rules
 iptables-save > /etc/iptables/rules.v4
 ip6tables-save > /etc/iptables/rules.v6
 
+##### Setup strongSwan site-to-site VPN #####
+
 # install swanctl
-sudo apt-get update -y
-sudo apt-get install -y strongswan-swanctl
+apt-get update -y
+apt-get install -y strongswan-swanctl charon-systemd
 
 # Root CA certificate
 cp /vagrant/pki/cert/rootCACert.pem /etc/swanctl/x509ca/

--- a/scripts/site_a_gateway.sh
+++ b/scripts/site_a_gateway.sh
@@ -23,3 +23,9 @@ cp /vagrant/pki/key/siteAKey.pem /etc/swanctl/private/
 
 # swanctl configurations
 cp /vagrant/config/swanctl-site-a.conf /etc/swanctl/swanctl.conf
+
+# load the certificates and private keys into the charon daemon
+swanctl --load-creds
+
+# load the connections defined in swanctl.conf
+swanctl --load-conns

--- a/scripts/site_b_gateway.sh
+++ b/scripts/site_b_gateway.sh
@@ -23,3 +23,9 @@ cp /vagrant/pki/key/siteBKey.pem /etc/swanctl/private/
 
 # swanctl configurations
 cp /vagrant/config/swanctl-site-b.conf /etc/swanctl/swanctl.conf
+
+# load the certificates and private keys into the charon daemon
+swanctl --load-creds
+
+# load the connections defined in swanctl.conf
+swanctl --load-conns

--- a/scripts/site_b_gateway.sh
+++ b/scripts/site_b_gateway.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 
-## NAT traffic going to the internet
-route add default gw 172.18.18.1
+##### Setup iptables rules #####
+
+# NAT traffic going to the internet
+route add default gw 172.16.16.1
 iptables -t nat -A POSTROUTING -o enp0s8 -j MASQUERADE
 
-## Save the iptables rules
+# Redirect traffic that was going to the local server to the cloud server
+# DNAT stands for Destination NAT
+ip addr add 10.1.0.99/16 dev enp0s9
+iptables -t nat -A PREROUTING -p tcp -d 10.1.0.99 --dport 8080 -j DNAT --to-destination 172.48.48.52:8080
+
+# Save the iptables rules
 iptables-save > /etc/iptables/rules.v4
 ip6tables-save > /etc/iptables/rules.v6
 
+##### Setup strongSwan site-to-site VPN #####
+
 # install swanctl
-sudo apt-get update -y
-sudo apt-get install -y strongswan-swanctl
+apt-get update -y
+apt-get install -y strongswan-swanctl charon-systemd
 
 # Root CA certificate
 cp /vagrant/pki/cert/rootCACert.pem /etc/swanctl/x509ca/

--- a/scripts/site_b_gateway.sh
+++ b/scripts/site_b_gateway.sh
@@ -7,3 +7,19 @@ iptables -t nat -A POSTROUTING -o enp0s8 -j MASQUERADE
 ## Save the iptables rules
 iptables-save > /etc/iptables/rules.v4
 ip6tables-save > /etc/iptables/rules.v6
+
+# install swanctl
+sudo apt-get update -y
+sudo apt-get install -y strongswan-swanctl
+
+# Root CA certificate
+cp /vagrant/pki/cert/rootCACert.pem /etc/swanctl/x509ca/
+
+# Site B certificate
+cp /vagrant/pki/cert/siteBCert.pem /etc/swanctl/x509/
+
+# Site B private key
+cp /vagrant/pki/key/siteBKey.pem /etc/swanctl/private/
+
+# swanctl configurations
+cp /vagrant/config/swanctl-site-b.conf /etc/swanctl/swanctl.conf


### PR DESCRIPTION
- `gen_cert.sh` generates certificates for gateways
- `config/`
  - configurations to setup site-to-site vpn using strongSwan
- `<site-name>_gateway.sh`
  - install swanctl
  - setup nat for the clients to reach the cloud server
  - copy the certificates and keys to the right folders
  - copy the configuration files to the right folders